### PR TITLE
Add check for standalone compilation to initial checklist

### DIFF
--- a/.github/ISSUE_TEMPLATE/90_tech-checklist.md
+++ b/.github/ISSUE_TEMPLATE/90_tech-checklist.md
@@ -52,6 +52,13 @@ assignees: ''
    - [ ] In the info box, ensure “20xx-repo-name” is replaced with the name of the repository so that the link points to the Issues page on Github.
    - [ ] Check that the live version of the paper now has the infobox in it with the correct links. You may need to go to the Actions page to check that the build process has completed, then go back to the live paper URL. You might need to reload the article without cache (In Chrome: Cmd + Shift + R (Mac) or Ctrl+ Shift + R (Windows)).
 - [ ] Compare the paper with the authors’ compiled version that the authors submitted. Sample the figures and interactive elements to see if they are present and work in the same way.
+- [ ] Check that the article works locally without an internet connection:
+   - [ ] Check out the repo and switch to whatever branch serves the site (e.g. `main` or `master` for sites without compilation, `gh-pages` for sites with compilation).
+   - [ ] With the internet off (e.g. in airplane mode), ensure the page loads in a browser. Sample the figures and interactive elements to see if they are present and work in the same way. You may need to use a local server from the repo directory:
+         
+      ```sh
+      python -m http.server
+      ```
 - [ ] From the main repo page (https://github.com/journalovi/20xx-repo-name), click the settings gear icon next to "About" on the right. (If you cannot see the “About” section, make your web browser window wider.)
    - [ ] Under "Description" enter "UNDER REVIEW"
    - [ ] Under "Website" tick "Use Your Github Pages Website".


### PR DESCRIPTION
This closes #3 